### PR TITLE
Branch caching - possibility to use tags for different versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Built on NodeJS for rock solid delivery!
 * Visit: https://gitcdn.xyz and paste your raw GitHub link into the field
 
 **or**
-1. Get the https://raw.githubusercontent.com address for the file you're looking for, it is in the following format: `https://raw.githubusercontent.com/USER/PROJECT/COMMIT/FILE`
+1. Get the https://raw.githubusercontent.com address for the file you're looking for, it is in the following format: `https://raw.githubusercontent.com/USER/PROJECT/BRANCH/FILE`
 **Example:** `https://raw.githubusercontent.com/schme16/gitcdn.xyz/master/README.md`
 
-2. **[Get latest commit]** Replace `https://raw.githubusercontent.com/` with `https://gitcdn.xyz/repo/` and switch the commit from /master/ to your designed commit sha1 **Example:** `https://gitcdn.xyz/repo/schme16/gitcdn.xyz/master/README.md`
+2. **[Get latest commit]** Replace `https://raw.githubusercontent.com/` with `https://gitcdn.xyz/repo/` and switch the commit from /master/ or /{TAG}/ to your designed commit sha1 **Example:** `https://gitcdn.xyz/repo/schme16/gitcdn.xyz/master/README.md` or `https://gitcdn.xyz/repo/schme16/gitcdn.xyz/v1.0.2/README.md`
 **[Get specific commit]** Replace `https://raw.githubusercontent.com/` with `https://gitcdn.xyz/cdn/` **Example:** `https://gitcdn.xyz/cdn/schme16/gitcdn.xyz/b5ccbec532d3cfe7eb9dec60b95317654a1be09f/README.md`
 
 ##How much does GitCDN cost?
-GitCDN is TOTALLY FREE! 
+GitCDN is TOTALLY FREE!
 That's not to say I won't have plans that have a monthly/yearly price in the future, but the repo CDN service will ALWAYS be free, without the need for sign-up!
 
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function createRedirectUrl (headers, meta, sha) {
 
 //Used for debugging during development
 function debugFunc (req, res, next) {
-    
+
     console.log(req.headers)
 
     next()
@@ -95,9 +95,9 @@ function repoFunc (req, res) {
         options.url = 'https://api.github.com/' + (meta.gist ? 'gists' : 'repos') + '/' + (meta.gist ? '' : meta.user + '/') + meta.repo + (meta.gist ? '' : '/commits/' + meta.branch + '?client_id=' + process.env.gitcdn_clientid + '&client_secret=' + process.env.gitcdn_clientsecret)
 
     /*if the repo is cached, just send that back, and update it for next time*/
-        if (cache[meta.user + '/' + meta.repo]) {
+        if (cache[meta.user + '/' + meta.repo + (meta.gist ? '' : '/' + meta.branch)]) {
             refreshCache = true
-            lastCall(meta, cache[meta.user + '/' + meta.repo], req, res)
+            lastCall(meta, cache[meta.user + '/' + meta.repo + (meta.gist ? '' : '/' + meta.branch)], req, res)
         }
 
     /*Update the repo, and cache it*/
@@ -133,11 +133,11 @@ function repoFunc (req, res) {
 function lastCall (meta, sha, req, res, cacheing) {
     if (sha && !cacheing) {
         var newUrl = createRedirectUrl(req.headers, meta, sha)
-        cache[meta.user + '/' + meta.repo] = sha
+        cache[meta.user + '/' + meta.repo + (meta.gist ? '' : '/' + meta.branch)] = sha
         res.redirect(301, newUrl)
     }
     else if (!!cacheing) {
-        cache[meta.user + '/' + meta.repo] = sha
+        cache[meta.user + '/' + meta.repo + (meta.gist ? '' : '/' + meta.branch)] = sha
     }
     else {
         if (!cacheing) res.sendStatus(500)
@@ -166,8 +166,3 @@ app.use(cors)
 app.get('/cdn/*', cdnFunc)
 app.get('/repo/*', repoFunc)
 app.listen(process.env.PORT || 8080)
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GitCDN",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GitCDN server",
   "keywords": [
     "OpenShift",


### PR DESCRIPTION
Hey Shane,

I think it could be really cool to have branch caching. I use GitCDN for my open source projects and it happened to me that I had to fix something. But problem was that your cache doesn't reflect versions - I mean tags. So it was problem because there wasn't any chance to clear the cache. This small feature will help.